### PR TITLE
OPSEXP-3278 Align java role to use common java home role argument default

### DIFF
--- a/changelogs/fragments/common-arg-spec.yaml
+++ b/changelogs/fragments/common-arg-spec.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Use common java home argument across roles and rely on default java version comming from role defaults

--- a/changelogs/fragments/common-arg-spec.yaml
+++ b/changelogs/fragments/common-arg-spec.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Use common java home argument across roles and rely on default java version comming from role defaults
+  - Use common java home argument across roles and rely on default java version coming from role defaults

--- a/roles/hxi_connector/defaults/main.yml
+++ b/roles/hxi_connector/defaults/main.yml
@@ -3,7 +3,7 @@
 hxi_connector_artifact_username: ''
 hxi_connector_artifact_password: ''
 
-hxi_connector_java_home_path: /opt/openjdk-17.0.15
+hxi_connector_java_home_path: /opt/java
 hxi_connector_java_bin_path: "{{ hxi_connector_java_home_path }}/bin/java"
 
 hxi_connector_artifact_base_path: /opt/alfresco/hxi-connector

--- a/roles/hxi_connector/molecule/default/converge.yml
+++ b/roles/hxi_connector/molecule/default/converge.yml
@@ -1,15 +1,20 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    molecule_java_home: /opt/java
   tasks:
     - name: Include java role
       ansible.builtin.include_role:
         name: alfresco.platform.java
+      vars:
+        java_home: "{{ molecule_java_home }}"
 
     - name: Include main role
       ansible.builtin.include_role:
         name: alfresco.platform.hxi_connector
       vars:
+        hxi_connector_java_home_path: "{{ molecule_java_home }}"
         hxi_connector_remote_ingestion_url: "https://hxinsight.alfresco.com"
         hxi_connector_remote_client_id: "client-id"
         hxi_connector_remote_client_secret: "client-secret"

--- a/roles/hxi_connector/molecule/default/converge.yml
+++ b/roles/hxi_connector/molecule/default/converge.yml
@@ -1,20 +1,15 @@
 ---
 - name: Converge
   hosts: all
-  vars:
-    molecule_java_home: /opt/java
   tasks:
     - name: Include java role
       ansible.builtin.include_role:
         name: alfresco.platform.java
-      vars:
-        java_home: "{{ molecule_java_home }}"
 
     - name: Include main role
       ansible.builtin.include_role:
         name: alfresco.platform.hxi_connector
       vars:
-        hxi_connector_java_home_path: "{{ molecule_java_home }}"
         hxi_connector_remote_ingestion_url: "https://hxinsight.alfresco.com"
         hxi_connector_remote_client_id: "client-id"
         hxi_connector_remote_client_secret: "client-secret"

--- a/roles/java/defaults/main.yml
+++ b/roles/java/defaults/main.yml
@@ -11,7 +11,7 @@ java_tar_file: >-
   OpenJDK{{ java_major }}U-jdk_{{ java_arch }}_linux_hotspot_{{ java_core }}_{{ java_build }}.tar.gz
 java_url: "{{ java_download_base }}/{{ java_tar_file }}"
 java_checksum: sha256:{{ java_url }}.sha256.txt
-java_home: /opt/openjdk-{{ java_core }}
+java_home: /opt/java
 java_truststore: "{{ java_home }}/lib/security/cacerts"
 java_truststore_pass: changeit
 

--- a/roles/java/defaults/main.yml
+++ b/roles/java/defaults/main.yml
@@ -11,6 +11,7 @@ java_tar_file: >-
   OpenJDK{{ java_major }}U-jdk_{{ java_arch }}_linux_hotspot_{{ java_core }}_{{ java_build }}.tar.gz
 java_url: "{{ java_download_base }}/{{ java_tar_file }}"
 java_checksum: sha256:{{ java_url }}.sha256.txt
+java_installation_home: /opt/openjdk-{{ java_core }}
 java_home: /opt/java
 java_truststore: "{{ java_home }}/lib/security/cacerts"
 java_truststore_pass: changeit

--- a/roles/java/meta/argument_specs.yml
+++ b/roles/java/meta/argument_specs.yml
@@ -9,24 +9,23 @@ argument_specs:
         type: str
         description: |
           Path to the java home (installation directory)
-        default: /opt/openjdk-17.0.14
+        default: /opt/java
       java_version:
         type: str
         description: |
           Version of the java to install
-        default: 17.0.14+7
       java_url:
         type: str
         description: |
           URL to download the java tarball
         default: >-
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.?14%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.14_7.tar.gz
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz
       java_checksum:
         type: str
         description: |
           Checksum of the java tarball in format hash_type:[hash_value|hash_url]
         default: >-
-          sha256:https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.?14%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.14_7.tar.gz.sha256.txt
+          sha256:https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz.sha256.txt
   keystores:
     short_description: Keystores entrypoint for the java role
     description: |
@@ -38,7 +37,7 @@ argument_specs:
         type: str
         description: |
           Path to the java home (installation directory)
-        default: /opt/openjdk-17.0.14
+        default: /opt/java
       java_keystore:
         required: true
         type: dict

--- a/roles/java/meta/argument_specs.yml
+++ b/roles/java/meta/argument_specs.yml
@@ -13,19 +13,16 @@ argument_specs:
       java_version:
         type: str
         description: |
-          Version of the java to install
+          Version of the java to install. Check defaults/main.yml for current default value.
       java_url:
         type: str
         description: |
-          URL to download the java tarball
-        default: >-
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz
+          URL to download the java tarball. Default is built from the java_version. Check defaults/main.yml for more details.
       java_checksum:
         type: str
         description: |
-          Checksum of the java tarball in format hash_type:[hash_value|hash_url]
-        default: >-
-          sha256:https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz.sha256.txt
+          Checksum of the java tarball in format hash_type:[hash_value|hash_url]. Default is built from the java_version.
+          Check defaults/main.yml for more details.
   keystores:
     short_description: Keystores entrypoint for the java role
     description: |

--- a/roles/java/molecule/default/verify.yml
+++ b/roles/java/molecule/default/verify.yml
@@ -8,7 +8,7 @@
 
     - name: Verify Java binary
       ansible.builtin.file:
-        path: /opt/openjdk-{{ java_core }}/bin/java
+        path: "{{ java_home }}/bin/java"
         state: file
         mode: "0755"
       register: java_binary

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -13,10 +13,19 @@
     - name: Extract OpenJDK archive {{ java_tar_file }}
       ansible.builtin.unarchive:
         src: "{{ java_download_location }}/{{ java_tar_file }}"
-        dest: "{{ java_home | dirname }}"
+        dest: "{{ java_installation_home | dirname }}"
         remote_src: true
-        creates: "{{ java_home }}"
+        creates: "{{ java_installation_home }}"
         owner: root
         group: root
         extra_opts:
-          - --xform=s,[^/]*,{{ java_home | basename }},
+          - --xform=s,[^/]*,{{ java_installation_home | basename }},
+
+    - name: Create symlink for java home
+      ansible.builtin.file:
+        src: "{{ java_installation_home }}"
+        dest: "{{ java_home }}"
+        state: link
+        owner: root
+        group: root
+        force: true


### PR DESCRIPTION
Ref: OPSEXP-3278
## Pull Request Checklist

- [x] Drop a changelog fragment in `changelogs/fragments` folder following the [antsibull-changelog](https://ansible.readthedocs.io/projects/antsibull-changelog/changelogs/#changelog-fragment-categories) format, if needed.
- [x] Update the role documentation, if needed.
