### PR TITLE
 OPSEXP-4179 Write systemd service environment to a root-owned 0600 EnvironmentFile

### DIFF
--- a/changelogs/fragments/systemd_service-environment-file.yaml
+++ b/changelogs/fragments/systemd_service-environment-file.yaml
@@ -1,0 +1,5 @@
+security_fixes:
+  - systemd_service - write the service environment (including database and
+    other credentials) to a root-owned ``EnvironmentFile`` with mode ``0600``
+    referenced from the unit, instead of embedding it as ``Environment=`` lines
+    in the world-readable (``0644``) unit file.

--- a/roles/systemd_service/defaults/main.yml
+++ b/roles/systemd_service/defaults/main.yml
@@ -7,6 +7,7 @@ systemd_service_unit_after: syslog.target network.target local-fs.target remote-
 systemd_service_type: simple
 systemd_service_user: ''
 systemd_service_environment: {}
+systemd_service_environment_file: /etc/systemd/system/{{ systemd_service_unit_name }}.env
 systemd_service_exec_start: ''
 systemd_service_exec_stop: kill -15 $MAINPID
 systemd_service_working_directory: /tmp

--- a/roles/systemd_service/meta/argument_specs.yml
+++ b/roles/systemd_service/meta/argument_specs.yml
@@ -28,6 +28,13 @@ argument_specs:
         type: dict
         description: Environment variables to set for the systemd service unit
         default: {}
+      systemd_service_environment_file:
+        type: str
+        description: |
+          Path to the root-owned, mode 0600 EnvironmentFile that holds the
+          environment variables (including secrets), keeping them out of the
+          world-readable unit file.
+        default: /etc/systemd/system/{{ systemd_service_unit_name }}.env
       systemd_service_exec_start:
         type: str
         description: Command to start the systemd service unit

--- a/roles/systemd_service/molecule/default/converge.yml
+++ b/roles/systemd_service/molecule/default/converge.yml
@@ -13,3 +13,4 @@
         systemd_service_environment:
           MY_ENV_VAR: my_value
           ANOTHER_ENV_VAR: another_value
+          PERCENT_ENV_VAR: p%ssw0rd

--- a/roles/systemd_service/molecule/default/verify.yml
+++ b/roles/systemd_service/molecule/default/verify.yml
@@ -7,6 +7,7 @@
       ansible.builtin.systemd:
         name: my-test-service
         state: started
+      register: service_status
 
     - name: Check service is enabled
       ansible.builtin.systemd:
@@ -23,4 +24,57 @@
         that:
           - journalctl_output.stdout_lines[0] == '-- No entries --'
         fail_msg: "Service logs contain warnings or errors: {{ journalctl_output.stdout }}"
+        quiet: true
+
+    - name: Stat the environment file
+      ansible.builtin.stat:
+        path: /etc/systemd/system/my-test-service.env
+      register: env_file
+
+    - name: Assert environment file is root-owned and not world-readable
+      ansible.builtin.assert:
+        that:
+          - env_file.stat.exists
+          - env_file.stat.pw_name == 'root'
+          - env_file.stat.mode == '0600'
+        fail_msg: "Environment file is not a root-owned 0600 file: {{ env_file.stat }}"
+        quiet: true
+
+    - name: Read the unit file
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/my-test-service.service
+      register: unit_file
+
+    - name: Assert the unit file contains no environment values
+      ansible.builtin.assert:
+        that:
+          - "'my_value' not in (unit_file.content | b64decode)"
+          - "'another_value' not in (unit_file.content | b64decode)"
+          - "'p%ssw0rd' not in (unit_file.content | b64decode)"
+        fail_msg: "Environment values leaked into the world-readable unit file"
+        quiet: true
+
+    - name: Read the environment file
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/my-test-service.env
+      register: env_file_content
+
+    - name: Assert percent values are written literally (not %%-escaped)
+      ansible.builtin.assert:
+        that:
+          - "'PERCENT_ENV_VAR=p%ssw0rd' in (env_file_content.content | b64decode)"
+          - "'p%%ssw0rd' not in (env_file_content.content | b64decode)"
+        fail_msg: "Percent sign was incorrectly escaped in the environment file"
+        quiet: true
+
+    - name: Read the main process environment
+      ansible.builtin.slurp:
+        src: /proc/{{ service_status.status.MainPID }}/environ
+      register: proc_environ
+
+    - name: Assert the running process sees the literal percent value
+      ansible.builtin.assert:
+        that:
+          - "'PERCENT_ENV_VAR=p%ssw0rd' in (proc_environ.content | b64decode)"
+        fail_msg: "Running process did not receive the expected literal environment value"
         quiet: true

--- a/roles/systemd_service/tasks/main.yml
+++ b/roles/systemd_service/tasks/main.yml
@@ -1,5 +1,16 @@
 ---
 # tasks file for systemd-service
+- name: Create systemd service environment file
+  ansible.builtin.template:
+    src: systemd-service.env.j2
+    dest: "{{ systemd_service_environment_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  notify:
+    - Systemd reload {{ systemd_service_unit_name }}
+    - Restart {{ systemd_service_unit_name }}
+
 - name: Create systemd service
   ansible.builtin.template:
     src: systemd-service.j2

--- a/roles/systemd_service/templates/systemd-service.env.j2
+++ b/roles/systemd_service/templates/systemd-service.env.j2
@@ -1,0 +1,3 @@
+{% for key, value in systemd_service_environment.items() %}
+{{ key }}={{ value }}
+{% endfor %}

--- a/roles/systemd_service/templates/systemd-service.j2
+++ b/roles/systemd_service/templates/systemd-service.j2
@@ -10,9 +10,7 @@ RemainAfterExit=yes
 
 User={{ systemd_service_user }}
 
-{% for key, value in systemd_service_environment.items() %}
-Environment="{{ key }}={{ value | replace('%', '%%') }}"
-{% endfor %}
+EnvironmentFile={{ systemd_service_environment_file }}
 
 ExecStart={{ systemd_service_exec_start }}
 ExecStop={{ systemd_service_exec_stop }}


### PR DESCRIPTION
OPSEXP-4179

## Pull Request Checklist

- [x] Drop a changelog fragment in `changelogs/fragments` folder following the [antsibull-changelog](https://ansible.readthedocs.io/projects/antsibull-changelog/changelogs/#changelog-fragment-categories) format, if needed.
- [x] Update the role documentation, if needed.
